### PR TITLE
logstash: config,patternfile respect `$::logstash::ensure`

### DIFF
--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -42,6 +42,7 @@
 # @author https://github.com/elastic/puppet-logstash/graphs/contributors
 #
 define logstash::configfile (
+  $ensure = $::logstash::ensure,
   $content = undef,
   $source = undef,
   $template = undef,
@@ -64,6 +65,7 @@ define logstash::configfile (
 
   if($config) {
     file { $config_file:
+      ensure  => $ensure,
       content => $config,
       owner   => $owner,
       group   => $group,
@@ -74,6 +76,7 @@ define logstash::configfile (
   }
   elsif($source) {
     file { $config_file:
+      ensure  => $ensure,
       source  => $source,
       owner   => $owner,
       group   => $group,

--- a/manifests/patternfile.pp
+++ b/manifests/patternfile.pp
@@ -20,6 +20,7 @@
 # @author https://github.com/elastic/puppet-logstash/graphs/contributors
 #
 define logstash::patternfile (
+  $ensure                                  = $::logstash::ensure,
   Pattern[/^(puppet|file):\/\//] $source   = undef,
   Optional[String[1]]            $filename = undef,
 ) {
@@ -28,7 +29,7 @@ define logstash::patternfile (
   $destination = pick($filename, basename($source))
 
   file { "${logstash::config_dir}/patterns/${destination}":
-    ensure => file,
+    ensure => $ensure,
     source => $source,
     owner  => 'root',
     group  => $logstash::logstash_group,


### PR DESCRIPTION
otherwise if a server has `ensure => false` but still calls `logstash::configfile` for any reason the file will try to be created but fail bc `/etc/logstash` does not exist

e.g. in your private `base.pp` you say
```
include logstash
logstash::configfile {
  ...
}
```
but somewhere in hiera you don't want to install `logstash` on a cluster so you have 
`logstash::ensure: absent`