### PR TITLE
Fix option spelling in jvm.options template

### DIFF
--- a/templates/jvm.options.erb
+++ b/templates/jvm.options.erb
@@ -10,11 +10,11 @@ defaults = {
   '-Xms' => '-Xms256m',
   '-Xmx' => '-Xmx1g',
   'UseParNewGC' => '-XX:+UseParNewGC',
-  'UseConcmarksweepgc' => '-XX:+UseConcMarkSweepGC',
+  'UseConcMarkSweepGC' => '-XX:+UseConcMarkSweepGC',
   'CMSInitiatingOccupancyFraction=' => '-XX:CMSInitiatingOccupancyFraction=75',
   'UseCMSInitiatingOccupancyOnly' => '-XX:+UseCMSInitiatingOccupancyOnly',
   'DisableExplicitGC' => '-XX:+DisableExplicitGC',
-  '-Djava.aws.headless=' => '-Djava.awt.headless=true',
+  '-Djava.awt.headless=' => '-Djava.awt.headless=true',
   '-Dfile.encoding=' => '-Dfile.encoding=UTF-8',
   'HeapDumpOnOutOfMemoryError' => '-XX:+HeapDumpOnOutOfMemoryError',
 }


### PR DESCRIPTION
The keys for 2 options are misspelled.

This may break users who have worked around this problem in their code
(ex: https://github.com/voxpupuli/puppet-logstash/issues/397#issue-532574154)